### PR TITLE
ci: write version to cloud2sql.com on tagging of stable releases

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -17,7 +17,7 @@ body:
     id: version
     attributes:
       label: Version
-      description: What version of Resoto are you running?
+      description: What version of Cloud2SQL are you running?
     validations:
       required: true
   - type: input
@@ -52,4 +52,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        By submitting this bug report, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
+        By submitting this bug report, I agree to follow the [code of conduct](https://cloud2sql.com/code-of-conduct).

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://discord.gg/someengineering
     about: Chat with other users and the development team
   - name: 📄 Documentation
-    url: https://resoto.com/docs
+    url: https://cloud2sql.com/docs
     about: Read and search documentation

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -28,4 +28,4 @@ body:
   - type: markdown
     attributes:
       value: |
-        By submitting this feature request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
+        By submitting this feature request, I agree to follow the [code of conduct](https://cloud2sql.com/code-of-conduct).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,7 +10,7 @@
 
 - [ ] Add test coverage for new or updated functionality
 - [ ] Lint and test with `tox`
-- [ ] Document new or updated functionality (someengineering/resoto.com#XXXX)
+- [ ] Document new or updated functionality (someengineering/cloud2sql.com#XXXX)
 
 # Issues Fixed
 
@@ -21,4 +21,4 @@
 
 # Code of Conduct
 
-By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
+By submitting this pull request, I agree to follow the [code of conduct](https://cloud2sql.com/code-of-conduct).

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -86,7 +86,7 @@ jobs:
     name: Update cloud2sql.com
     if: github.ref_type == 'tag'
     needs:
-      - build
+      - cloud2sql
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -2,7 +2,7 @@ name: Check PR cloud2sql
 on:
   push:
     tags:
-      - "*.*.*"
+      - '*.*.*'
     branches:
       - main
   pull_request:
@@ -12,7 +12,7 @@ on:
 
 jobs:
   cloud2sql:
-    name: "cloud2sql"
+    name: 'cloud2sql'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -42,11 +42,8 @@ jobs:
 
       - name: Build a binary wheel and a source tarball
         run: >-
-          python -m
-          build
-          --sdist
-          --wheel
-          --outdir dist/
+          python -m build --sdist --wheel --outdir dist/
+
 
       - name: Publish distribution to PyPI
         if: github.ref_type == 'tag'
@@ -84,3 +81,66 @@ jobs:
         with:
           name: ${{ steps.pyinstaller.outputs.target }}
           path: dist/${{ steps.pyinstaller.outputs.target }}
+
+  docs:
+    name: Update cloud2sql.com
+    if: github.ref_type == 'tag'
+    needs:
+      - build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Get release tag and type
+        id: release
+        shell: bash
+        run: |
+          GITHUB_REF="${{ github.ref }}"
+          tag=${GITHUB_REF##*/}
+          echo "tag=${tag}" >> $GITHUB_OUTPUT
+
+          if [[ ${{ github.ref }} =~ ^refs/tags/[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "prerelease=false" >> $GITHUB_OUTPUT
+          else
+            echo "prerelease=true" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Check out someengineering/cloud2sql.com
+        if: steps.release.outputs.prerelease == 'false'
+        uses: actions/checkout@v3
+        with:
+          repository: someengineering/cloud2sql.com
+          path: cloud2sql.com
+          token: ${{ secrets.SOME_CI_PAT }}
+
+      - name: Update released version
+        if: steps.release.outputs.prerelease == 'false'
+        shell: bash
+        working-directory: ./cloud2sql.com
+        run: |
+          echo $(jq '.version="${{ steps.release.outputs.tag }}" | .link="https://github.com/someengineering/cloud2sql/releases/tag/${{ steps.release.outputs.tag }}"' latestRelease.json) > latestRelease.json
+          yarn format
+
+      - name: Create someengineering/cloud2sql.com pull request
+        if: steps.release.outputs.prerelease == 'false'
+        uses: peter-evans/create-pull-request@v4
+        env:
+          HUSKY: 0
+        with:
+          path: cloud2sql.com
+          commit-message: 'chore: update Cloud2SQL version to ${{ steps.release.outputs.tag }}'
+          title: 'chore: update Cloud2SQL version to ${{ steps.release.outputs.tag }}'
+          body: |
+            Updates Cloud2SQL version on cloud2sql.com to `${{ steps.release.outputs.tag }}`.
+          labels: |
+            🤖 bot
+          branch: ${{ steps.release.outputs.tag }}
+          delete-branch: true
+          token: ${{ secrets.SOME_CI_PAT }}
+          committer: C.K. <98986935+some-ci@users.noreply.github.com>
+          author: C.K. <98986935+some-ci@users.noreply.github.com>
+
+      - name: Create release
+        uses: ncipollo/release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: ${{steps.release.outputs.prerelease}}


### PR DESCRIPTION
# Description

Write version number to someengineering/cloud2sql.com repo and automatically generate GitHub release.

Also see:

- [someengineering/cloud2sql.com](https://github.com/someengineering/cloud2sql.com)

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://resoto.com/code-of-conduct).
