### PR TITLE
Ignore failure to publish to PyPI in CI

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -47,6 +47,7 @@ jobs:
 
       - name: Publish distribution to PyPI
         if: github.ref_type == 'tag'
+        continue-on-error: true # Ignore failure to publish to PyPI (e.g., when re-tagging a release)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           user: __token__


### PR DESCRIPTION
# Description

Allow for re-tagging of a release.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://cloud2sql.com/code-of-conduct).
