### PR TITLE
Bump resotolib >= 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ resotoclient>=1.2.1
 posthog>=2.2.0
 requests>=2.28.2
 
-resotolib>=3.3, <3.4
+resotolib>=3.3.2, <3.4
 # all collector plugins
 resoto-plugin-aws>=3.3, <3.4
 resoto-plugin-digitalocean>=3.3, <3.4


### PR DESCRIPTION
# Description

Bump resotolib >= 3.3.2

Note: Action will fail until resotolib-3.3.2 has been build. I'll rerun failing tests.

# Code of Conduct

By submitting this pull request, I agree to follow the [code of conduct](https://cloud2sql.com/code-of-conduct).
